### PR TITLE
fix: expose ./dist/cjs/types.js in package.json exports for @modelcon…

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "./*": {
       "import": "./dist/esm/*",
       "require": "./dist/cjs/*"
-    }
+    },
+    "./types": "./dist/cjs/types.js"
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
…textprotocol/sdk

- Add "./types": "./dist/cjs/types.js" to the "exports" field in package.json.
- Allows correct import of types from the MCP SDK in TypeScript projects using ts-node or internal paths.
- Fixes "Cannot find module .../dist/cjs/types" error when running custom MCP servers.
- Improves integration and extension of the SDK in modern Node.js environments.